### PR TITLE
Allows specification of a base path for the mock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Or use the [docker image](https://hub.docker.com/r/realfengjia/fakeit)
         --static             generate static response
         --static-types       generate static value for specified types, e.g. --static-types integer,string
         --static-properties  generate static value for specified properties, e.g. --static-properties id,uuid
+        --base-path          mounts the mock server at the given path, e.g. --base-path /api
 
     other options:
         -v, --version
@@ -96,7 +97,8 @@ Request and response:
   ],
   "static_properties": [
     "id"
-  ]
+  ],
+  "base_path": "/"
 }
 ```
 

--- a/bin/fakeit
+++ b/bin/fakeit
@@ -16,6 +16,7 @@ begin
     o.bool '--static', 'generate static response'
     o.array '--static-types', 'generate static value for specified types, e.g. --static-types integer,string'
     o.array '--static-properties', 'generate static value for specified properties, e.g. --static-properties id,uuid'
+    o.string '--base-path', 'mounts the mock server at the given path, e.g. --base-path /api'
     o.separator ''
     o.separator 'other options:'
     o.on '-v', '--version' do
@@ -50,7 +51,8 @@ options = Fakeit::App::Options.new(
   use_example: opts.use_example?,
   static: opts.static?,
   static_types: opts[:static_types],
-  static_properties: opts[:static_properties]
+  static_properties: opts[:static_properties],
+  base_path: opts[:base_path]
 )
 app = Fakeit.build(opts[:spec], options)
 

--- a/lib/fakeit/app/app_builder.rb
+++ b/lib/fakeit/app/app_builder.rb
@@ -2,6 +2,7 @@ module Fakeit
   module App
     class AppBuilder
       def initialize(spec_file, options)
+        @options = options
         @config_route = Routes::ConfigRoute.new(options)
         @openapi_route = Routes::OpenapiRoute.new(spec_file)
       end
@@ -14,9 +15,20 @@ module Fakeit
           when '/__fakeit_config__'
             @config_route.call(request)
           else
+            request.path_info = trim_base_from_path(request.path_info)
             @openapi_route.call(request, @config_route.options)
           end
         end
+      end
+
+      private
+
+      def trim_base_from_path(path)
+        return path if @options.base_path == '/'
+
+        return path unless path.start_with?(@options.base_path)
+
+        path[@options.base_path.length-1..]
       end
     end
   end

--- a/lib/fakeit/app/options.rb
+++ b/lib/fakeit/app/options.rb
@@ -1,14 +1,17 @@
 module Fakeit
   module App
     class Options
-      attr_reader :permissive, :use_example
+      attr_reader :permissive, :use_example, :base_path
 
-      def initialize(permissive: false, use_example: false, static: false, static_types: [], static_properties: [])
+      def initialize(permissive: false, use_example: false, static: false, static_types: [], static_properties: [], base_path: "/")
         @permissive = permissive
         @use_example = use_example
         @static = static
         @static_types = static_types
         @static_properties = static_properties
+        # Standardize the base path to include trailing slash
+        # so that `/base` matches `/base/path` but doesn't match `/basement/path`
+        @base_path = base_path[-1] == '/' ? base_path : "#{base_path}/"
       end
 
       def use_static?(type: nil, property: nil)
@@ -21,7 +24,8 @@ module Fakeit
           use_example: @use_example,
           static: @static,
           static_types: @static_types,
-          static_properties: @static_properties
+          static_properties: @static_properties,
+          base_path: @base_path
         }
       end
     end

--- a/spec/fakeit/app/app_builder_spec.rb
+++ b/spec/fakeit/app/app_builder_spec.rb
@@ -1,11 +1,12 @@
 describe Fakeit::App::AppBuilder do
   subject { Fakeit::App::AppBuilder.new(spec_file, options).build }
 
-  let(:options) { 'options' }
   let(:spec_file) { 'spec_file' }
   let(:env) { 'env' }
   let(:request) { double(Rack::Request) }
+  let(:base_path) { '/' }
 
+  let(:options) { double(Fakeit::App::Options, base_path: base_path) }
   let(:openapi_route) { double(Fakeit::App::Routes::OpenapiRoute) }
   let(:config_route) { double(Fakeit::App::Routes::ConfigRoute, options: options) }
 
@@ -25,9 +26,23 @@ describe Fakeit::App::AppBuilder do
 
   it 'handles openapi route' do
     allow(request).to receive(:path_info).and_return('/other')
+    allow(request).to receive(:path_info=).with('/other')
 
     expect(openapi_route).to receive(:call).with(request, options)
 
     subject[env]
+  end
+
+  context 'when base_path is not the root' do
+    let(:base_path) { '/some_base_path/' }
+
+    it 'handles openapi route' do
+      allow(request).to receive(:path_info).and_return('/some_base_path/other')
+
+      expect(request).to receive(:path_info=).with('/other')
+      expect(openapi_route).to receive(:call).with(request, options)
+
+      subject[env]
+    end
   end
 end

--- a/spec/fakeit/app/options_spec.rb
+++ b/spec/fakeit/app/options_spec.rb
@@ -23,6 +23,14 @@ describe Fakeit::App::Options do
     expect(option.use_static?(type: 'integer', property: 'name')).to be(false)
   end
 
+  it 'ensures the base_path always terminates in a slash' do
+    ['/some_base_path/', '/some_base_path'].each do |base_path|
+      option = Fakeit::App::Options.new(base_path: base_path)
+
+      expect(option.base_path).to eq('/some_base_path/')
+    end
+  end
+
   it 'to hash' do
     option = Fakeit::App::Options.new
 
@@ -31,7 +39,8 @@ describe Fakeit::App::Options do
       use_example: false,
       static: false,
       static_types: [],
-      static_properties: []
+      static_properties: [],
+      base_path: '/'
     )
   end
 end

--- a/spec/fakeit/app/routes/config_route_spec.rb
+++ b/spec/fakeit/app/routes/config_route_spec.rb
@@ -28,7 +28,8 @@ describe Fakeit::App::Routes::ConfigRoute do
         use_example: true,
         static: true,
         static_types: ['string'],
-        static_properties: ['id']
+        static_properties: ['id'],
+        base_path: '/'
       }
     end
     let(:parse_result) { { data: config } }

--- a/spec/fakeit_spec.rb
+++ b/spec/fakeit_spec.rb
@@ -238,7 +238,8 @@ describe Fakeit do
         'use_example' => false,
         'static' => false,
         'static_types' => [],
-        'static_properties' => []
+        'static_properties' => [],
+        'base_path' => '/'
       )
     end
 
@@ -256,7 +257,8 @@ describe Fakeit do
         'use_example' => true,
         'static' => true,
         'static_types' => ['string'],
-        'static_properties' => ['id']
+        'static_properties' => ['id'],
+        'base_path' => '/'
       }
     end
 


### PR DESCRIPTION
Provides a new parameter, `--base-path /some/base/path`, that ensures the mock server returns the spec's endpoints underneath it. E.g. `/api-call` will present at `/some/base/path/api-call`.